### PR TITLE
Document Provider: some changes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="29"
       android:versionName="1.5.0">
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/src/com/seafile/seadroid2/SeafConnection.java
+++ b/src/com/seafile/seadroid2/SeafConnection.java
@@ -509,7 +509,7 @@ public class SeafConnection {
             if (msg != null)
                 Log.d(DEBUG_TAG, msg);
             else
-                Log.d(DEBUG_TAG, "get upload link error");
+                Log.d(DEBUG_TAG, "get upload link error", e);
             throw SeafException.unknownException;
         }
     }

--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -88,7 +88,11 @@ public class Account implements Parcelable {
     public String getSignature() {
         return email.substring(0, 4) + " " + hashCode();
     }
-    
+
+    public String getFullSignature() {
+        return email+"@"+server;
+    }
+
     public String getName() {
         return email.substring(0, email.indexOf("@")) + "@" + getServerHost();
     }

--- a/src/com/seafile/seadroid2/account/AccountDBHelper.java
+++ b/src/com/seafile/seadroid2/account/AccountDBHelper.java
@@ -43,6 +43,7 @@ public class AccountDBHelper extends SQLiteOpenHelper {
             return dbHelper;
         dbHelper = new AccountDBHelper(context);
         dbHelper.database = dbHelper.getWritableDatabase();
+        AccountNotifier.notifyProvider();
         return dbHelper;
     }
 

--- a/src/com/seafile/seadroid2/data/SeafStarredFile.java
+++ b/src/com/seafile/seadroid2/data/SeafStarredFile.java
@@ -37,6 +37,14 @@ public class SeafStarredFile implements SeafItem {
         }
     }
 
+    public long getSize() {
+        return size;
+    }
+
+    public long getMtime() {
+        return mtime;
+    }
+
     public boolean isDir() {
         return (type == FileType.DIR);
     }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -94,7 +94,8 @@ public class DocumentIdParser {
         String[] list = documentId.split(DOC_SEPERATOR, 3);
         if (list.length>2) {
             String path = list[2];
-            return path;
+            if (path.length()>0)
+                return path;
         }
         return ProviderUtil.PATH_SEPERATOR;
     }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -39,6 +39,7 @@ public class DocumentIdParser {
 
     /** used to separate serverName, RepoId and Path. */
     private static final String DOC_SEPERATOR = "::::";
+    private static final String STARRED_FILE_REPO_ID = "starred-file-magic-repo";
 
     Context context;
 
@@ -117,4 +118,11 @@ public class DocumentIdParser {
             return a.getFullSignature();
     }
 
+    public static String buildStarredFilesId(Account a) {
+        return a.getFullSignature() + DOC_SEPERATOR + STARRED_FILE_REPO_ID;
+    }
+
+    public static boolean isStarredFiles(String documentId) {
+        return getRepoIdFromId(documentId).equals(STARRED_FILE_REPO_ID);
+    }
 }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -19,8 +19,6 @@ package com.seafile.seadroid2.provider;
 
 import android.content.Context;
 
-import com.seafile.seadroid2.R;
-import com.seafile.seadroid2.SeadroidApplication;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.account.AccountDBHelper;
 
@@ -65,9 +63,7 @@ public class DocumentIdParser {
                 }
             }
         }
-        throw new FileNotFoundException(SeadroidApplication.getAppContext()
-                .getResources()
-                .getString(R.string.saf_account_not_found_exception));
+        throw new FileNotFoundException();
     }
 
     /**

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -27,9 +27,9 @@ import java.io.FileNotFoundException;
 /**
  * Helper class to create and parse DocumentIds for the DocumentProvider
  *
- * Format: ServerName::::RepoId::::Path
+ * Format: FullServerServerSignature::RepoId::Path
  * Example:
- * https://server.com/seafile/::::550e8400-e29b-11d4-a716-446655440000::::/dir/file.jpg
+ * email@adress.com@https://server.com/seafile/::::550e8400-e29b-11d4-a716-446655440000::::/dir/file.jpg
  *
  * the separation using "::::" is arbitrary. Is has to be something, that is neither in an URL
  * nor in a repoId UUID.
@@ -58,7 +58,7 @@ public class DocumentIdParser {
         if (list.length > 0) {
             String server = list[0];
             for (Account a: AccountDBHelper.getDatabaseHelper(context).getAccountList()) {
-                if (a.getServer().equals(server)) {
+                if (a.getFullSignature().equals(server)) {
                     return a;
                 }
             }
@@ -109,11 +109,11 @@ public class DocumentIdParser {
      */
     public static String buildId(Account a, String repoId, String path) {
         if (repoId != null && path != null)
-            return a.getServer() + DOC_SEPERATOR + repoId + DOC_SEPERATOR + path;
+            return a.getFullSignature() + DOC_SEPERATOR + repoId + DOC_SEPERATOR + path;
         else if (repoId != null)
-            return a.getServer() + DOC_SEPERATOR + repoId;
+            return a.getFullSignature() + DOC_SEPERATOR + repoId;
         else
-            return a.getServer();
+            return a.getFullSignature();
     }
 
 }

--- a/src/com/seafile/seadroid2/provider/ProviderUtil.java
+++ b/src/com/seafile/seadroid2/provider/ProviderUtil.java
@@ -67,8 +67,11 @@ public class ProviderUtil {
      * @returns the parent directory.
      */
     public static String getParentDirFromPath(String path) {
-        int lastSlash = path.lastIndexOf('/');
-        return path.substring(0, lastSlash);
+        int lastSlash = path.lastIndexOf(ProviderUtil.PATH_SEPERATOR);
+        if (lastSlash == 0)
+            return ProviderUtil.PATH_SEPERATOR;
+        else
+            return path.substring(0, lastSlash);
     }
 
     /**
@@ -79,7 +82,7 @@ public class ProviderUtil {
      * @returns the filename.
      */
     public static String getFileNameFromPath(String path) {
-        int lastSlash = path.lastIndexOf('/');
+        int lastSlash = path.lastIndexOf(ProviderUtil.PATH_SEPERATOR);
         return path.substring(lastSlash + 1);
     }
 

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -221,9 +221,7 @@ public class SeafileProvider extends DocumentsProvider {
             if (!parentDocumentId.equals(lastQueriedDocumentId)) {
 
                 lastQueriedDocumentId = parentDocumentId;
-
                 result = createCursor(netProjection, true);
-
                 fetchDirentAsync(dm, repoId, path, result);
 
             } else {
@@ -233,7 +231,6 @@ public class SeafileProvider extends DocumentsProvider {
             // in the meantime return cached ones
             List<SeafDirent> dirents = dm.getCachedDirents(repoId, path);
             if (dirents != null) {
-
                 for (SeafDirent d : dirents) {
                     includeDirent(result, dm, repoId, path, d);
                 }
@@ -258,7 +255,6 @@ public class SeafileProvider extends DocumentsProvider {
         String repoId = DocumentIdParser.getRepoIdFromId(documentId);
         if (repoId.isEmpty()) {
             // the user has asked for the root, that contains all the repositories as children.
-            // we don't have much to say about that "directory".
 
             includeRoot(result, dm.getAccount());
             return result;
@@ -278,13 +274,12 @@ public class SeafileProvider extends DocumentsProvider {
             // about the repository itself, not some directory in it.
             includeRepo(result, dm.getAccount(), repo);
         } else {
-            // the generic case. a query about a file/directory in a repository.
+            // the general case. a query about a file/directory in a repository.
 
             // again we only use cached info in this function. that shouldn't be an issue, as
             // very likely there has been a SeafileProvider.queryChildDocuments() call just moments
             // earlier.
 
-            // the file might not be cached. try to find the file in the dirent of its parent directory.
             String parentPath = ProviderUtil.getParentDirFromPath(path);
             List<SeafDirent> dirents = dm.getCachedDirents(repo.getID(), parentPath);
             List<SeafStarredFile> starredFiles = dm.getCachedStarredFiles();
@@ -310,8 +305,7 @@ public class SeafileProvider extends DocumentsProvider {
             }
         }
 
-
-        return(result);
+        return result;
     }
 
     @Override
@@ -324,7 +318,6 @@ public class SeafileProvider extends DocumentsProvider {
                                              String mode,
                                              final CancellationSignal signal)
             throws FileNotFoundException {
-
 
         DataManager dm = createDataManager(documentId);
 
@@ -543,6 +536,7 @@ public class SeafileProvider extends DocumentsProvider {
                                 SeafRepo repo, 
                                 String path)
             throws FileNotFoundException {
+
         try {
             // fetch the file from the Seafile server.
             File f = dm.getFile(repo.getName(), repo.getID(), path, new ProgressMonitor() {
@@ -762,8 +756,7 @@ public class SeafileProvider extends DocumentsProvider {
                 } catch (SeafException e) {
                     Log.e(getClass().getSimpleName(), "Exception while querying server", e);
                 }
-                // notify the client in any case.
-                // XXX: the API is unclear about this. we could also let him wait forever.
+                // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
             }
         });
@@ -801,7 +794,7 @@ public class SeafileProvider extends DocumentsProvider {
     /**
      * Create a new DataManager (which gives us access to the Seafile cache and server).
      *
-     * @param documentId documentId, must contain at least a serverName.
+     * @param documentId documentId, must contain at least the account
      * @return dataManager object.
      * @throws FileNotFoundException if documentId is bogus or the account does not exist.
      */

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -208,10 +208,14 @@ public class SeafileProvider extends DocumentsProvider {
             // in this case, the repository is known. the user wants the entries of a specific
             // directory in the given repository.
 
-            String path = DocumentIdParser.getPathFromId(parentDocumentId);
+            SeafRepo repo = dm.getCachedRepoByID(repoId);
+
+            // encrypted repos are not supported (we can't ask the user for the passphrase)
+            if (repo.encrypted) {
+                throw new FileNotFoundException();
+            }
 
             MatrixCursor result;
-
 
             // fetch new dirents in the background
             if (!parentDocumentId.equals(lastQueriedDocumentId)) {

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -84,7 +84,9 @@ public class SeafileProvider extends DocumentsProvider {
                     Document.COLUMN_DISPLAY_NAME,
                     Document.COLUMN_LAST_MODIFIED,
                     Document.COLUMN_FLAGS,
-                    Document.COLUMN_SIZE
+                    Document.COLUMN_SIZE,
+                    Document.COLUMN_ICON,
+                    Document.COLUMN_SUMMARY
             };
     
     /** we remember the last documentId queried so we don't run into a loop while doing Async lookups. */
@@ -483,13 +485,25 @@ public class SeafileProvider extends DocumentsProvider {
     private void includeRepo(MatrixCursor result, Account account, SeafRepo repo) {
         String docId = DocumentIdParser.buildId(account, repo.getID(), null);
 
+        int flags = 0;
+        if (repo.hasWritePermission()) {
+            flags |= Document.FLAG_DIR_SUPPORTS_CREATE;
+        }
+
         final MatrixCursor.RowBuilder row = result.newRow();
         row.add(Document.COLUMN_DOCUMENT_ID, docId);
         row.add(Document.COLUMN_DISPLAY_NAME, repo.getTitle());
-        row.add(Document.COLUMN_SIZE, repo.size);
-        row.add(Document.COLUMN_MIME_TYPE, DocumentsContract.Document.MIME_TYPE_DIR);
+        row.add(Document.COLUMN_SUMMARY, repo.description);
         row.add(Document.COLUMN_LAST_MODIFIED, repo.mtime.getTime() * 1000);
-        row.add(Document.COLUMN_FLAGS, 0);
+        row.add(Document.COLUMN_FLAGS, flags);
+        row.add(Document.COLUMN_ICON, repo.getIcon());
+        row.add(Document.COLUMN_SIZE, repo.size);
+
+        if (repo.encrypted) {
+            row.add(Document.COLUMN_MIME_TYPE, null); // undocumented: will grey out the entry
+        } else {
+            row.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+        }
     }
 
     /**
@@ -502,22 +516,32 @@ public class SeafileProvider extends DocumentsProvider {
      * @param entry the seafile dirent to add
      */
     private void includeDirent(MatrixCursor result, DataManager dm, String repoId, String parentPath, SeafDirent entry) {
-        String fullPath = parentPath + ProviderUtil.PATH_SEPERATOR + entry.getTitle();
+        String fullPath = Utils.pathJoin(parentPath, entry.getTitle());
+
         String docId = DocumentIdParser.buildId(dm.getAccount(), repoId, fullPath);
 
         final String mimeType = ProviderUtil.getTypeForFile(docId, entry.isDir());
 
         int flags = 0;
-        // only offer a thumbnail if the file is an image and it is cached.
+        // only offer a thumbnail if the file is an image
         if (mimeType.startsWith("image/")) {
-            // Allow the image to be represented by a thumbnail rather than an icon
             flags |= Document.FLAG_SUPPORTS_THUMBNAIL;
+        }
+
+        SeafRepo repo = dm.getCachedRepoByID(repoId);
+        if (repo.hasWritePermission()) {
+            if (entry.isDir()) {
+                flags |= Document.FLAG_DIR_SUPPORTS_CREATE;
+            } else {
+                flags |= Document.FLAG_SUPPORTS_WRITE;
+            }
         }
 
         final MatrixCursor.RowBuilder row = result.newRow();
         row.add(Document.COLUMN_DOCUMENT_ID, docId);
         row.add(Document.COLUMN_DISPLAY_NAME, entry.getTitle());
         row.add(Document.COLUMN_SIZE, entry.size);
+        row.add(Document.COLUMN_SUMMARY, null);
         row.add(Document.COLUMN_MIME_TYPE, mimeType);
         row.add(Document.COLUMN_LAST_MODIFIED, entry.mtime * 1000);
         row.add(Document.COLUMN_FLAGS, flags);

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -114,7 +114,7 @@ public class SeafileProvider extends DocumentsProvider {
 
             row.add(Root.COLUMN_ROOT_ID, a.getServerHost());
             row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
-            row.add(Root.COLUMN_FLAGS, 0);
+            row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD);
             row.add(Root.COLUMN_TITLE, a.getName());
             row.add(Root.COLUMN_DOCUMENT_ID, a.getServer());
         }
@@ -249,6 +249,11 @@ public class SeafileProvider extends DocumentsProvider {
 
 
         return(result);
+    }
+
+    @Override
+    public boolean isChildDocument(String parentId, String documentId) {
+        return documentId.startsWith(parentId);
     }
 
     @Override

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -74,6 +74,7 @@ public class SeafileProvider extends DocumentsProvider {
             Root.COLUMN_FLAGS,
             Root.COLUMN_TITLE,
             Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_SUMMARY,
             Root.COLUMN_ICON
     };
 
@@ -110,13 +111,7 @@ public class SeafileProvider extends DocumentsProvider {
 
         // add a Root for every Seafile account we have.
         for(Account a: AccountDBHelper.getDatabaseHelper(getContext()).getAccountList()) {
-            MatrixCursor.RowBuilder row = result.newRow();
-
-            row.add(Root.COLUMN_ROOT_ID, a.getServerHost());
-            row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
-            row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD);
-            row.add(Root.COLUMN_TITLE, a.getName());
-            row.add(Root.COLUMN_DOCUMENT_ID, a.getServer());
+            includeRoot(result, a);
         }
 
         // notification uri for the event, that the account list has changed
@@ -469,12 +464,13 @@ public class SeafileProvider extends DocumentsProvider {
         String docId = DocumentIdParser.buildId(account, null, null);
 
         final MatrixCursor.RowBuilder row = result.newRow();
-        row.add(Document.COLUMN_DOCUMENT_ID, docId);
-        row.add(Document.COLUMN_DISPLAY_NAME, account.getServerHost());
-        row.add(Document.COLUMN_SIZE, 0);
-        row.add(Document.COLUMN_MIME_TYPE, DocumentsContract.Document.MIME_TYPE_DIR);
-        row.add(Document.COLUMN_LAST_MODIFIED, 0);
-        row.add(Document.COLUMN_FLAGS, 0);
+
+        row.add(Root.COLUMN_ROOT_ID, docId);
+        row.add(Root.COLUMN_DOCUMENT_ID, docId);
+        row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
+        row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD | Root.FLAG_SUPPORTS_CREATE);
+        row.add(Root.COLUMN_TITLE, account.getServerHost());
+        row.add(Root.COLUMN_SUMMARY, account.getEmail());
     }
 
     /**


### PR DESCRIPTION
These are a couple of patches to the Seafile Document Provider.

I've split them into a patchset for easier reviewing. However each patch by itself will very likely not compile.

* Support writing (uploading) files
* Support creating files/directories
* Show starred files
* Improve repository list: use seafile icons for repositories, show descriptions
* fix: don't allow user to enter encrypted repos. that was previously broken.
* improve account (root) list: display account email adress in 2nd line
* use a thread pool for concurrent tasks (instead of spawning a new Thread each time)
* remove verbose FileNotFoundExceptions (with translated strings). they aren't shown to the user anyway.
* some refactoring
* some small fixes

List of roots:
![roots](https://cloud.githubusercontent.com/assets/676900/6541894/cefb8c84-c4e7-11e4-866a-92af4a070877.png)

List of repositories:
![repos](https://cloud.githubusercontent.com/assets/676900/6541896/de6418ee-c4e7-11e4-9434-2d0d83b8f376.png)
